### PR TITLE
Make sending alerts on job failures optional. Disabled by default.

### DIFF
--- a/app/rearview/Global.scala
+++ b/app/rearview/Global.scala
@@ -30,6 +30,7 @@ object Global extends WithFilters(LoggingFilter) {
 
   lazy val accessLogging        = config.getBoolean("access_logging").getOrElse(false)
   lazy val alertClassNames      = config.getStringList("alert.class_names").map(_.toList).getOrElse(Nil)
+  lazy val alertOnErrors        = config.getBoolean("alert.on_errors").getOrElse(false)
   lazy val clusterInterfaces    = config.getString("cluster.interfaces").getOrElse("").split(',').map(_.trim).filterNot(_.isEmpty)
   lazy val clusterGroupName     = config.getString("cluster.groupName").getOrElse("rearview")
   lazy val emailFrom            = config.getString("email.from").getOrElse(exitMsg("email.from must be defined in configuration"))

--- a/app/rearview/job/Scheduled.scala
+++ b/app/rearview/job/Scheduled.scala
@@ -33,6 +33,8 @@ trait Scheduled {
 
   def alertClients: Seq[Alert]
 
+  def alertOnErrors: Boolean
+
   /**
    * Main execution for a Job/monitor. Upon running the Monitor use the handleResults method to issue any alerts, etc.
    * @param job
@@ -91,7 +93,7 @@ trait Scheduled {
    * @param result
    */
   def sendAlerts(job: Job, status: JobStatus, result: AnalysisResult) {
-    if(status != SuccessStatus) {
+    if(status == FailedStatus || (alertOnErrors && status != SuccessStatus)) {
       job.id.foreach { jobId =>
         val lastErrorOpt = JobDAO.findErrorsByJobId(jobId, 1).headOption.map(_.date)
 
@@ -170,4 +172,5 @@ trait Scheduled {
 case object ScheduledJob extends Scheduled {
   implicit val graphiteClient = LiveGraphiteClient
   val alertClients            = Global.alertClients
+  val alertOnErrors           = Global.alertOnErrors
 }

--- a/conf/common.conf
+++ b/conf/common.conf
@@ -110,8 +110,16 @@ graphite.host="http://localhost:8080"
 graphite.auth=""
 graphite.timeout=10000
 
+# Alerts
+# ~~~~~~
 # An array of class names to load on startup for alerting
 alert.class_names = []
+
+# Enable alerts (Email, PagerDuty ..) for Graphite and other internal errors (disabled by default). 
+# This means that alerts will only be sent when the monitor successfully runs and raises an alert. 
+# Set the value to true to enable alerts in cases where the monitor fails to fetch data, times out 
+# or when there is a security exception in the ruby sandbox
+alert.on_errors=false
 
 # pager duty
 pagerduty.uri="https://events.pagerduty.com/generic/2010-04-15/create_event.json"

--- a/test/rearview/job/SchedulerSpec.scala
+++ b/test/rearview/job/SchedulerSpec.scala
@@ -79,8 +79,8 @@ class SchedulerSpec extends Specification with FutureMatchers with JobsControlle
     lazy val scheduledJobFactory = new Scheduled {
       override val runOnce     = true
       lazy val graphiteClient  = self.graphiteClient
-
       lazy val alertClients = List(pagerDutyAlert, emailAlert)
+      lazy val alertOnErrors = false
     }
   }
 


### PR DESCRIPTION
I set up Rearview for a couple of live services. It works great except it sends out Email and PagerDuty alerts even when the job fails for "internal" errors. For example, in cases where there was a one-off error fetching data from Graphite or when the monitor timed out. Such cases don't warrant waking up someone in the middle of the night!

Please see [issue 8](https://github.com/livingsocial/rearview/issues/8) for a couple of examples.
