### PR TITLE
Add instructions for setting up Rearview on EC2

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,8 +189,8 @@ until the end of the series.
 graph will render 3 lines, with the labels "# of Impressions", "# of Conversions" and "Conversion Rate".
 
 
-Installation
-============
+Installation & Deployment
+=========================
 
 Clone this repo:
 
@@ -217,6 +217,8 @@ Try hitting the server with your browser:
 
 You should see a Rearview page with a message indicating you must login via Google (you must use a
 GMail account which matches the configured domain for openid).
+
+To deploy on Amazon EC2 with an RDS instance, follow the detailed instructions [here](https://github.com/livingsocial/rearview/wiki/Setting-up-Rearview-on-EC2-with-Amazon-RDS).
 
 
 Development


### PR DESCRIPTION
I added instructions for setting up Rearview on EC2 instance with Amazon RDS to the wiki. Adding a link to it in the Readme. 
